### PR TITLE
Add sample_weight, frozen_medoids/Dist_init, and callable distance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,13 @@ jobs:
           python -m pip install .[test]
 
       - name: Run tests
-        run: python -m pytest tests/ -v
+        run: python -m pytest tests/ -v --cov=onebatch --cov-report=xml
+
+      - name: Upload coverage
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml
 
       - name: Smoke test
         run: |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# OnebatchPAM
+# OneBatchPAM
+
+[![CI](https://github.com/antoinedemathelin/onebatch/actions/workflows/ci.yml/badge.svg)](https://github.com/antoinedemathelin/onebatch/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/antoinedemathelin/onebatch/branch/main/graph/badge.svg)](https://codecov.io/gh/antoinedemathelin/onebatch)
+[![Python 3.9-3.12](https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue)](https://github.com/antoinedemathelin/onebatch)
+[![PyPI](https://img.shields.io/pypi/v/onebatch)](https://pypi.org/project/onebatch/)
 
 Implementation of [OneBatchPAM: A Fast and Frugal K-Medoids Algorithm](https://arxiv.org/pdf/2501.19285) (AAAI 2025)
 

--- a/onebatch/onebatchpam.py
+++ b/onebatch/onebatchpam.py
@@ -171,7 +171,7 @@ class OneBatchPAM:
         self.random_state = random_state
 
 
-    def fit(self, X):
+    def fit(self, X, sample_weight=None, frozen_medoids=None, Dist_init=None):
         """
         Find the medoids on the provided data.
 
@@ -198,9 +198,19 @@ class OneBatchPAM:
         if self.n_medoids > X.shape[0]:
             raise ValueError("The number of medoids cannot"
                              " exceed the dataset size")
-        
+
+        if frozen_medoids is not None and Dist_init is not None:
+            raise ValueError(
+                "Cannot specify both 'frozen_medoids' and 'Dist_init'."
+            )
+        if frozen_medoids is not None and self.distance == "precomputed":
+            raise ValueError(
+                "'frozen_medoids' is not supported with distance='precomputed'. "
+                "Use 'Dist_init' directly instead."
+            )
+
         rng = np.random.default_rng(self.random_state)
-        
+
         if self.distance == "precomputed":
             Dist = safe_ensure_c_contiguous_f32(X)
             batch_size = X.shape[1]
@@ -215,34 +225,76 @@ class OneBatchPAM:
             if batch_size > X.shape[0]:
                 batch_size = X.shape[0]
             batch_indexes = rng.choice(X.shape[0], batch_size, replace=False)
-            Dist = pairwise_distances(X, X[batch_indexes], metric=self.distance, n_jobs=self.n_jobs)
+            if callable(self.distance):
+                Dist = self.distance(X, X[batch_indexes], self.n_jobs)
+            else:
+                Dist = pairwise_distances(X, X[batch_indexes], metric=self.distance, n_jobs=self.n_jobs)
             Dist = safe_ensure_c_contiguous_f32(Dist)
+
+        frozen_mask = None
+        if frozen_medoids is not None:
+            frozen_medoids = np.asarray(frozen_medoids, dtype=np.float32)
+            if callable(self.distance):
+                frozen_dist_full = self.distance(
+                    X, frozen_medoids, self.n_jobs
+                )
+            else:
+                frozen_dist_full = pairwise_distances(
+                    X, frozen_medoids,
+                    metric=self.distance, n_jobs=self.n_jobs
+                )
+            frozen_dist_full = frozen_dist_full.min(axis=1)
+            Dist_init = frozen_dist_full[batch_indexes].astype(np.float32)
+            frozen_mask = frozen_dist_full > Dist.min(axis=1)
+
+        if Dist_init is not None:
+            Dist_init = np.asarray(Dist_init, dtype=np.float32)
 
         if self.normalize:
             maxv = Dist.max()
             if maxv > 0:
                 Dist /= np.float32(maxv)
+                if Dist_init is not None:
+                    Dist_init = Dist_init / np.float32(maxv)
 
         if self.weighting:
             assign = Dist.argmin(1)
-            sample_weight = np.zeros(Dist.shape[1], dtype=np.float32)
-            unique, counts = np.unique(assign, return_counts=True)
-            sample_weight[unique] = counts.astype(np.float32)
-            meanw = sample_weight.mean()
+            batch_weight = np.zeros(Dist.shape[1], dtype=np.float32)
+
+            w_assign = assign
+            w_sample_weight = sample_weight
+            if frozen_mask is not None:
+                w_assign = assign[frozen_mask]
+                if sample_weight is not None:
+                    w_sample_weight = sample_weight[frozen_mask]
+
+            if w_sample_weight is not None:
+                np.add.at(batch_weight, w_assign, w_sample_weight)
+            else:
+                unique, counts = np.unique(w_assign, return_counts=True)
+                batch_weight[unique] = counts.astype(np.float32)
+
+            meanw = batch_weight.mean()
             if meanw > 0:
-                sample_weight /= meanw
-            Dist *= sample_weight
+                batch_weight /= meanw
+            Dist *= batch_weight
+            if Dist_init is not None:
+                Dist_init = Dist_init * batch_weight
 
         medoids_init = rng.choice(X.shape[0], self.n_medoids, replace=False)
         medoids_init = np.array(medoids_init, dtype=np.dtype("i"))
-        
+
+        if Dist_init is not None:
+            Dist_init = np.ascontiguousarray(Dist_init, dtype=np.float32)
+
         self.solution_ = swap_eager(Dist,
                                     medoids_init,
                                     self.n_medoids,
                                     self.max_iter,
                                     X.shape[0],
                                     batch_size,
-                                    np.float32(self.tol))
+                                    np.float32(self.tol),
+                                    Dist_init)
                         
         self.medoid_indices_ = self.solution_["medoids"]
         self.labels_ = self.solution_["nearest"]
@@ -277,7 +329,10 @@ class OneBatchPAM:
         `labels_` obtained during `fit` or compute distances to the
         `cluster_centers_` externally and take argmin.
         """
-        Dist = pairwise_distances(X, self.cluster_centers_, metric=self.distance, n_jobs=self.n_jobs)
+        if callable(self.distance):
+            Dist = self.distance(X, self.cluster_centers_, self.n_jobs)
+        else:
+            Dist = pairwise_distances(X, self.cluster_centers_, metric=self.distance, n_jobs=self.n_jobs)
         return Dist.argmin(1)
 
 

--- a/onebatch/pam.pyx
+++ b/onebatch/pam.pyx
@@ -5,7 +5,7 @@ from cpython.array cimport array, clone
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def swap_eager(float[:, ::1] Dist, int[::1] medoids_init, int K, int n_swap, int N, int B, float tol_init):
+def swap_eager(float[:, ::1] Dist, int[::1] medoids_init, int K, int n_swap, int N, int B, float tol_init, float[::1] Dist_init=None):
     
     cdef array[float] templatef = array('f')
     cdef array[int] templatei = array('i')
@@ -25,6 +25,7 @@ def swap_eager(float[:, ::1] Dist, int[::1] medoids_init, int K, int n_swap, int
     cdef bint not_medoid_init = 1
     cdef bint not_medoid
     cdef bint finish = 0
+    cdef bint has_dist_init = Dist_init is not None
 
     cdef float[::1] min_Dist_to_med = clone(templatef, B, False)
     cdef float[::1] second_min_Dist_to_med = clone(templatef, B, False)
@@ -52,11 +53,17 @@ def swap_eager(float[:, ::1] Dist, int[::1] medoids_init, int K, int n_swap, int
                     else:
                         index2 = k
                         sec_dist = Dist[medoids[k], j]
+            if has_dist_init:
+                if first_dist > Dist_init[j]:
+                    sec_dist = Dist_init[j]
+                    first_dist = Dist_init[j]
+                elif sec_dist > Dist_init[j]:
+                    sec_dist = Dist_init[j]
             min_Dist_to_med[j] = first_dist
             second_min_Dist_to_med[j] = sec_dist
             nearest[j] = index1
             second[j] = index2
-        
+
         for j in range(B):
             k = nearest[j]
             swap_gains_K[k] += min_Dist_to_med[j] - second_min_Dist_to_med[j]
@@ -125,6 +132,12 @@ def swap_eager(float[:, ::1] Dist, int[::1] medoids_init, int K, int n_swap, int
                                         else:
                                             index2 = k
                                             sec_dist = Dist[medoids[k], j]
+                                if has_dist_init:
+                                    if first_dist > Dist_init[j]:
+                                        sec_dist = Dist_init[j]
+                                        first_dist = Dist_init[j]
+                                    elif sec_dist > Dist_init[j]:
+                                        sec_dist = Dist_init[j]
                                 min_Dist_to_med[j] = first_dist
                                 second_min_Dist_to_med[j] = sec_dist
                                 nearest[j] = index1

--- a/tests/test_onebatchpam.py
+++ b/tests/test_onebatchpam.py
@@ -113,3 +113,124 @@ class TestEdgeCases:
         model = OneBatchPAM(n_medoids=10, random_state=0)
         model.fit(X)
         assert len(model.medoid_indices_) == 10
+
+
+class TestSampleWeight:
+
+    def test_uniform_weight_matches_no_weight(self, random_data):
+        model1 = OneBatchPAM(n_medoids=5, random_state=42)
+        model1.fit(random_data)
+
+        uniform_w = np.ones(random_data.shape[0], dtype=np.float32)
+        model2 = OneBatchPAM(n_medoids=5, random_state=42)
+        model2.fit(random_data, sample_weight=uniform_w)
+
+        np.testing.assert_array_equal(model1.medoid_indices_, model2.medoid_indices_)
+
+    def test_sample_weight_changes_result(self, random_data):
+        rng = np.random.RandomState(99)
+        weights = rng.exponential(1.0, size=random_data.shape[0]).astype(np.float32)
+        model = OneBatchPAM(n_medoids=5, random_state=42)
+        model.fit(random_data, sample_weight=weights)
+        assert len(model.medoid_indices_) == 5
+
+    def test_sample_weight_ignored_when_no_weighting(self, random_data):
+        model1 = OneBatchPAM(n_medoids=5, weighting=False, random_state=42)
+        model1.fit(random_data)
+
+        weights = np.ones(random_data.shape[0], dtype=np.float32) * 5.0
+        model2 = OneBatchPAM(n_medoids=5, weighting=False, random_state=42)
+        model2.fit(random_data, sample_weight=weights)
+
+        np.testing.assert_array_equal(model1.medoid_indices_, model2.medoid_indices_)
+
+    def test_sample_weight_with_precomputed(self, random_data):
+        dist_matrix = pairwise_distances(random_data).astype(np.float32)
+        weights = np.ones(random_data.shape[0], dtype=np.float32)
+        model = OneBatchPAM(n_medoids=5, distance="precomputed", random_state=42)
+        model.fit(dist_matrix, sample_weight=weights)
+        assert len(model.medoid_indices_) == 5
+
+
+class TestDistInit:
+
+    def test_dist_init_large_no_effect(self, random_data):
+        model1 = OneBatchPAM(n_medoids=5, random_state=42, batch_size=50)
+        model1.fit(random_data)
+
+        dist_init = np.full(50, 1e6, dtype=np.float32)
+        model2 = OneBatchPAM(n_medoids=5, random_state=42, batch_size=50)
+        model2.fit(random_data, Dist_init=dist_init)
+
+        np.testing.assert_array_equal(model1.medoid_indices_, model2.medoid_indices_)
+
+    def test_dist_init_small_changes_result(self, random_data):
+        dist_init = np.full(50, 1e-6, dtype=np.float32)
+        model = OneBatchPAM(n_medoids=5, random_state=42, batch_size=50)
+        model.fit(random_data, Dist_init=dist_init)
+        assert len(model.medoid_indices_) == 5
+
+    def test_dist_init_precomputed(self, random_data):
+        dist_matrix = pairwise_distances(random_data).astype(np.float32)
+        batch_size = dist_matrix.shape[1]
+        dist_init = np.full(batch_size, 1e6, dtype=np.float32)
+        model = OneBatchPAM(n_medoids=5, distance="precomputed", random_state=42)
+        model.fit(dist_matrix, Dist_init=dist_init)
+        assert len(model.medoid_indices_) == 5
+
+
+class TestFrozenMedoids:
+
+    def test_frozen_medoids_basic(self, random_data):
+        frozen = random_data[:3]
+        model = OneBatchPAM(n_medoids=5, random_state=42)
+        model.fit(random_data, frozen_medoids=frozen)
+        assert len(model.medoid_indices_) == 5
+
+    def test_frozen_and_dist_init_raises(self, random_data):
+        frozen = random_data[:3]
+        dist_init = np.ones(50, dtype=np.float32)
+        model = OneBatchPAM(n_medoids=5, random_state=42, batch_size=50)
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            model.fit(random_data, frozen_medoids=frozen, Dist_init=dist_init)
+
+    def test_frozen_with_precomputed_raises(self, random_data):
+        dist_matrix = pairwise_distances(random_data).astype(np.float32)
+        frozen = random_data[:3]
+        model = OneBatchPAM(n_medoids=5, distance="precomputed", random_state=42)
+        with pytest.raises(ValueError, match="not supported"):
+            model.fit(dist_matrix, frozen_medoids=frozen)
+
+
+class TestCallableDistance:
+
+    def test_callable_matches_string(self, random_data):
+        model1 = OneBatchPAM(n_medoids=5, distance="euclidean", random_state=42)
+        model1.fit(random_data)
+
+        def my_euclidean(X, Y, n_jobs):
+            return pairwise_distances(X, Y, metric="euclidean", n_jobs=n_jobs)
+
+        model2 = OneBatchPAM(n_medoids=5, distance=my_euclidean, random_state=42)
+        model2.fit(random_data)
+
+        np.testing.assert_array_equal(model1.medoid_indices_, model2.medoid_indices_)
+
+    def test_callable_predict(self, random_data):
+        def my_euclidean(X, Y, n_jobs):
+            return pairwise_distances(X, Y, metric="euclidean", n_jobs=n_jobs)
+
+        model = OneBatchPAM(n_medoids=5, distance=my_euclidean, random_state=42)
+        model.fit(random_data)
+        labels = model.predict(random_data)
+        assert labels.shape == (200,)
+        assert all(0 <= l < 5 for l in labels)
+
+    def test_callable_with_frozen(self, random_data):
+        def my_euclidean(X, Y, n_jobs):
+            return pairwise_distances(X, Y, metric="euclidean", n_jobs=n_jobs)
+
+        frozen = random_data[:3]
+        model = OneBatchPAM(n_medoids=5, distance=my_euclidean, random_state=42)
+        model.fit(random_data, frozen_medoids=frozen)
+        assert len(model.medoid_indices_) == 5


### PR DESCRIPTION
## Summary

- **Sample weights**: `fit()` accepts `sample_weight` parameter. When `weighting=True`, accumulates per-sample weights into batch columns via `np.add.at` instead of counting. Fast `np.unique` path preserved when `sample_weight=None`.
- **Frozen medoids / Dist_init**: `fit()` accepts `frozen_medoids` (2D coordinates) or `Dist_init` (per-batch upper bound). Acts as a virtual non-swappable medoid in the Cython kernel via distance clamping on `min_Dist_to_med` and `second_min_Dist_to_med`. Samples covered by frozen medoids are excluded from weighting via a mask. Zero performance overhead when not used.
- **Callable distance**: `distance` parameter can be a callable with signature `(X, Y, n_jobs)` for custom distance functions, used in both `fit()` and `predict()`.
- **README badges**: CI status, codecov coverage, Python versions (3.9–3.12), PyPI.
- **CI**: Added `--cov` to pytest and codecov upload step.

## Test plan
- [ ] All 14 existing tests pass unchanged (backward compatibility)
- [ ] 4 new `TestSampleWeight` tests: uniform matches no-weight, non-uniform works, ignored when `weighting=False`, works with precomputed
- [ ] 3 new `TestDistInit` tests: large Dist_init has no effect, small changes result, works with precomputed
- [ ] 3 new `TestFrozenMedoids` tests: basic fit, both params raises, precomputed raises
- [ ] 3 new `TestCallableDistance` tests: matches string euclidean, predict works, works with frozen medoids
- [ ] CI passes on all platforms (ubuntu, macOS, windows) × Python 3.9–3.12